### PR TITLE
GitHup copilot found the bug.

### DIFF
--- a/src/jobdata.rs
+++ b/src/jobdata.rs
@@ -125,9 +125,14 @@ pub async fn process_sql_queries(
     pool: &Option<sqlx::Pool<MySql>>,
     args: &CliArgs,
 ) -> Result<()> {
-    // Create a new transaction for this job if we have a database connection
+    // Create a new transaction for this job only if we have a database connection
+    // and we are not in dry-run mode.
     let mut tx_per_job = if let Some(p) = pool.as_ref() {
-        Some(p.begin().await?)
+        if !args.dry_run {
+            Some(p.begin().await?)
+        } else {
+            None
+        }
     } else {
         None
     };


### PR DESCRIPTION

- lmx2db does not directly import into runs table
- it can, however, create a valid file import.sql
- this file imports into runs table correctly
- this error is reproducible with several mariadb userIDs
- the corresponding unit test succeeds
