### PR TITLE
122 improve informational message for default database url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -830,7 +830,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lmx2db"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lmx2db"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Dr. Christoph Pospiech <pospiech-HD@t-online.de>"]
 description = "A tool to import data from LMX files into a database."
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -167,17 +167,18 @@ Common options:
 
 ### Output to SQL file
 
-- The default value of `[-u|--db-url]` is "output_to_files_only".
-  This is a special case of an invalid database URL.
-- If the database URL is invalid (which includes the default value),
-  `lmx2db` will write the SQL queries to a file (see option `-f, --sql-file`).
-- Worst case it takes a TCP/IP timeout to find out that the
+- The default value of `[-u|--db-url]` is an empty string.
+  An informational message is printed and `lmx2db` progresses with
+  file output without attempting to access the database.
+- If the database URL is invalid, `lmx2db` will also write
+  the SQL queries to a file (see option `-f, --sql-file`).
+- In the worst case it takes a TCP/IP timeout to find out that the
   database URL is invalid.
 - If the database cannot be queried for the correct schema and data types
   for each table column, this information has to be provided in a file.
-- The shipped sample file `sqltypes.yml` is automatically picked up as
-  the default sqltypes file. It is under version control and is based on
-  the database schema in subdirectory `schema`. This file can be used if
+- The shipped sample file `sqltypes.yml` is automatically taken as
+  default. It is under version control and is based on the database
+  schema in subdirectory `schema`. This file can be used if
   the database schema of the intended database fits the one given in
   subdirectory `schema`.
 - Alternatively, a correct sqltypes file can be created on a different

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ Common options:
   database URL is invalid.
 - If the database cannot be queried for the correct schema and data types
   for each table column, this information has to be provided in a file.
-- The shipped sample file `sqltypes.yml` is automatically taken as
-  default. It is under version control and is based on the database
+- The shipped sample file `sqltypes.yml` is automatically used as the
+  default sqltypes file. It is under version control and is based on the database
   schema in subdirectory `schema`. This file can be used if
   the database schema of the intended database fits the one given in
   subdirectory `schema`.

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ Common options:
 ### Output to SQL file
 
 - The default value of `[-u|--db-url]` is an empty string.
-  An informational message is printed and `lmx2db` progresses with
+  An informational message is printed and `lmx2db` proceeds with
   file output without attempting to access the database.
 - If the database URL is invalid, `lmx2db` will also write
   the SQL queries to a file (see option `-f, --sql-file`).

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -34,12 +34,7 @@ pub struct CliArgs {
     pub dry_run: bool,
 
     /// Database URL
-    #[arg(
-        short = 'u',
-        long,
-        env = "LMX2DB_DATABASE_URL",
-        default_value = "output_to_files_only"
-    )]
+    #[arg(short = 'u', long, env = "LMX2DB_DATABASE_URL", default_value = "")]
     pub db_url: String,
 
     /// name of sqltypes file

--- a/src/cmdline/cmdline_tests.rs
+++ b/src/cmdline/cmdline_tests.rs
@@ -28,7 +28,7 @@ mod tests {
             assert!(!args.dry_run);
             assert!(!args.create_sqltypes);
             assert!(!args.do_import);
-            assert_eq!(args.db_url, "output_to_files_only");
+            assert_eq!(args.db_url, "");
             assert_eq!(args.sqltypes_file, "sqltypes.yml");
             assert_eq!(args.sql_file, "import.sql");
             assert_eq!(args.module_file, "modules.yml");

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,13 +42,18 @@ async fn main() -> Result<()> {
 
     // Connect to the database
     let database_url: String = args.db_url.clone();
-    let pool: Option<Pool<MySql>> = connect_to_database(&database_url).await;
+    let pool: Option<Pool<MySql>> = if database_url.is_empty() {
+        println!("No database URL provided. Will output to file instead.");
+        None
+    } else {
+        connect_to_database(&database_url).await
+    };
 
     // If create_sqltypes flag is set, create the sqltype file
     // from the database and exit
     if args.create_sqltypes {
         sqltypes::create_sqltype_file(pool.clone(), &args).await?;
-        std::process::exit(0);
+        return Ok(());
     }
     // Normal operation: read sqltypes and proceed
     let sqltypes: SqlTypeHashMap = sqltypes::read_sqltypes(pool.clone(), &args).await?;
@@ -67,6 +72,8 @@ async fn main() -> Result<()> {
     }
 
     // Explicit disconnect from the database
-    disconnect_from_database(pool).await;
+    if let Some(pool) = pool {
+        disconnect_from_database(Some(pool)).await;
+    }
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ async fn main() -> Result<()> {
     // from the database and exit
     if args.create_sqltypes {
         sqltypes::create_sqltype_file(pool.clone(), &args).await?;
+        disconnect_from_database(pool).await;
         return Ok(());
     }
     // Normal operation: read sqltypes and proceed

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,9 @@ async fn main() -> Result<()> {
     // Connect to the database
     let database_url: String = args.db_url.clone();
     let pool: Option<Pool<MySql>> = if database_url.is_empty() {
-        println!("No database URL provided. Will output to file instead.");
+        if !args.create_sqltypes {
+            println!("No database URL provided. Will output to file instead.");
+        }
         None
     } else {
         connect_to_database(&database_url).await

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,8 +75,6 @@ async fn main() -> Result<()> {
     }
 
     // Explicit disconnect from the database
-    if let Some(pool) = pool {
-        disconnect_from_database(Some(pool)).await;
-    }
+    disconnect_from_database(pool).await;
     Ok(())
 }


### PR DESCRIPTION
The default value for database URL is now an empty string. A connect to the database will not be attempted, but a file will be immediately created. The `README.md` was adapted to this case.